### PR TITLE
Set blocking fallback to use SSR to serve newly created blog pages

### DIFF
--- a/pages/blog/[id].tsx
+++ b/pages/blog/[id].tsx
@@ -127,7 +127,7 @@ export const getStaticPaths: GetStaticPaths = async () => {
 
     return {
         paths,
-        fallback: false,
+        fallback: 'blocking',
     }
 }
   


### PR DESCRIPTION
`getStaticPaths` gets called at build time, so pages with a new blog id will spit out 404 instead of the newly created blog post. Setting `fallback` to `blocking` will use SSR to fetch new posts that are not present in the fetched ids at build time.